### PR TITLE
Don't split escaped entities in foldLine

### DIFF
--- a/mime-functions.js
+++ b/mime-functions.js
@@ -57,7 +57,7 @@ this.foldLine = function(str, maxLength, foldAnywhere, afterSpace){
                 response += line.substr(0,lf)+"\r\n"+(!foldAnywhere && !afterSpace && "       " || "");
                 curpos -= line.substr(lf).length;
             }else{
-                line = line.replace(/=+$/, "");
+                line = line.replace(/=[a-f0-9]?$/i, "");
                 response+=line + "\r\n";
             }
         }


### PR DESCRIPTION
There was a bug in my previous pull request; we don't need to check for multiple = (because they've already been encoded as =3D) and we need to ensure that we don't split a =XX sequence
