### PR TITLE
Fix for CRLF handling in parseHeaders

### DIFF
--- a/mime-functions.js
+++ b/mime-functions.js
@@ -272,7 +272,7 @@ this.parseHeaders = function(headers){
     headers = headers.replace(/(\r?\n|\r)([ \t])/gm," ");
 
     // split lines
-    lines = headers.split(/(\r?\n|\r)/);
+    lines = headers.split(/\r?\n|\r/);
     for(i=0; i<lines.length;i++){
         if(!lines[i]) // no more header lines
             break;


### PR DESCRIPTION
Grouped regex doesn't play nicely with String.split apparently

``` javascript
// this fails in the current build
mimelib.parseHeaders('Subject: hi\r\n');
```
