### PR TITLE
Fixed passing a surrogate pair to encodeQuotedPrintable threw a URIError.

### DIFF
--- a/mime-functions.js
+++ b/mime-functions.js
@@ -146,7 +146,7 @@ this.encodeQuotedPrintable = function(str, mimeWord, charset){
      * \n + \r OK
      */
     
-    str = str.replace(/[^\sa-zA-Z\d]/gm,function(c){
+    str = str.replace(/(?:[\ud800-\udbff][\udc00-\udfff])|[^\sa-zA-Z\d]/gm,function(c){
         if(!!mimeWord){
             if(c=="?")return "=3F";
             if(c=="_")return "=5F";


### PR DESCRIPTION
Passing a surrogate pair to `encodeQuotedPrintable` threw a `URIError` because it passed individual words to `encodeURIComponent`.

For example,

```
encodeQuotedPrintable('\udbba\udf04')
```

throw a `URIError` because it finally called `encodeURIComponent('\uddba')`, which threw a `URIError`.

This patch changed encodeQuotedPrintable to treat surrogate pairs specially and pass them to encodeURIComponent as a pair.
