### PR TITLE
Dont insert soft line breaks between hex sequences

### DIFF
--- a/lib/mimelib.js
+++ b/lib/mimelib.js
@@ -545,7 +545,10 @@ function addQPSoftLinebreaks(mimeEncodedStr, lineLengthMax){
         }
         
         if(pos + line.length < len && line.substr(-1)!="\n"){
-            if(line.length==76){
+            if(line.length==76 && line.match(/\=[\da-f]{2}$/i)){
+                line = line.substr(0, line.length-3);
+            }
+            else if(line.length==76){
                 line = line.substr(0, line.length-1);
             }
             pos += line.length;

--- a/test/mimelib.js
+++ b/test/mimelib.js
@@ -9,6 +9,13 @@ exports["Quoted printable"] = {
         test.done();
     },
 
+    "Don't wrap between encoded chars": function(test){
+        var wrapped = "a__________________________",
+            wrappedEncoded = "a=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=5F=\r\n=5F=5F";
+        test.equal(wrappedEncoded, mimelib.encodeQuotedPrintable(wrapped));
+        test.done();
+    },
+
     "Encode long string": function(test){
         var longLine = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"+
                        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"+


### PR DESCRIPTION
When you are trimming lines to the 76 character limit, sometimes you split in the middle of an encoded sequence.
