### PR TITLE
Fix incorrectly decoding strings

### DIFF
--- a/lib/mimelib.js
+++ b/lib/mimelib.js
@@ -211,7 +211,7 @@ module.exports.mimeFunctions = {
 
         for(var i=0, len = str.length; i<len; i++){
             chr = str.charAt(i);
-            if(chr == "=" && (hex = str.substr(i+1, 2).match(/[\da-fA-F]{2}/))){
+            if(chr == "=" && (hex = str.substr(i+1, 2)) && /[\da-fA-F]{2}/.test(hex)){
                 buffer[bufferPos++] = parseInt(hex, 16);
                 i+=2;
                 continue;


### PR DESCRIPTION
parseInt is defined as taking string parameter; behavior in node.js is unpredictable when anything other than a string is passed
