### PR TITLE
Do not coalesce MIME encoded-words in order to avoid base64 breakage.

### DIFF
--- a/lib/mimelib.js
+++ b/lib/mimelib.js
@@ -319,21 +319,9 @@ module.exports.mimeFunctions = {
         var remainder = "", lastCharset, curCharset;
         str = (str || "").toString();
 
-        while(str.match(/(\=\?[\w_\-]+\?[QB]\?[^\?]+\?\=)\s+(?=\=\?[\w_\-]+\?[QB]\?[^\?]+\?\=)/g)){
-            str = str.replace(/(\=\?[\w_\-]+\?[QB]\?[^\?]+\?\=)\s+(\=\?[\w_\-]+\?[QB]\?[^\?]+\?\=)/g,function(original, first, second){
-                var match1 = (first || "").trim().match(/^\=\?([\w_\-]+)\?([QB])\?([^\?]+)\?\=$/),
-                    match2 = (second || "").trim().match(/^\=\?([\w_\-]+)\?([QB])\?([^\?]+)\?\=$/);
-
-                if(match1[1] == match2[1] && match1[2] == match2[2]){
-                    return "=?"+match1[1]+"?"+match1[2]+"?"+match1[3] + match2[3]+"?=";
-                }else{
-                    return first+second;
-                }
-
-            });
-        }
-
-        str = str.replace(/\=\?([\w_\-]+)\?([QB])\?[^\?]+\?\=/g, (function(mimeWord, charset, encoding){
+        str = str.
+                replace(/(=\?[^?]+\?[QqBb]\?[^?]+\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]+\?=)/g, "$1").
+                replace(/\=\?([\w_\-]+)\?([QB])\?[^\?]+\?\=/g, (function(mimeWord, charset, encoding){
 
                       curCharset = charset + encoding;
 

--- a/test/mimelib.js
+++ b/test/mimelib.js
@@ -97,6 +97,7 @@ exports["Mime Words"] = {
 
     "Parse Mime Words": function(test){
         test.equal("Jõge-vaŽ zz Jõge-vaŽJõge-vaŽJõge-vaŽ", mimelib.parseMimeWords("=?ISO-8859-13?Q?J=F5ge-va=DE?= zz =?ISO-8859-13?Q?J=F5ge-va=DE?= =?ISO-8859-13?Q?J=F5ge-va=DE?= =?ISO-8859-13?Q?J=F5ge-va=DE?="))
+        test.equal("Sssś Lałalalala", mimelib.parseMimeWords("=?UTF-8?B?U3NzxZsgTGHFgmFsYQ==?= =?UTF-8?B?bGFsYQ==?="));
         test.done();
     },
 


### PR DESCRIPTION
decodeMimeWords() currently merges adjacent MIME encoded-words with the same encoding type and character set.  This does not reliably work for base64 encoded words.  For example, a variation on the following was witnessed in the display name portion of a mail address in a message composed by Thunderbird (I changed the non-accented characters since the person's name is not actually relevant):

```
=?UTF-8?B?U3NzxZsgTGHFgmFsYQ==?= =?UTF-8?B?bGFsYQ==?=
```

ends up as the following alleged base64 string that gets fed to new Buffer(..., 'base64'):

```
U3NzxZsgTGHFgmFsYQ==bGFsYQ==
```

which results in the following test failure from the test case added in this patch (without the fix):

```
AssertionError: 'Sssś Lałalalala' == 'Sssś Lałala\u0006�\u0016�\u0010'
```

I belive the goal of the code was to accomplish the removal of whitespace between consecutive MIME encoded words, plus an attempt at optimization.  This patch just transplants the logic from mailparser's _replaceMimeWords function for whitespace removal since it's much more terse.

One could argue that the optimizing logic should just not merge 'B' encoded words.  However, I think given that RFC2047 says "The 'encoded-text' in an 'encoded-word' must be self-contained", one could argue that coalescing the encoded words will lead to different behaviour in cases where the data is not self-contained and so decoding the encoded words separately is more correct.  I favor getting rid of the optimizing logic because it's more complex and has no comment justifying the coalescing logic.
