### PR TITLE
Update mimelib.js

### DIFF
--- a/lib/mimelib.js
+++ b/lib/mimelib.js
@@ -308,7 +308,7 @@ module.exports.mimeFunctions = {
 
         var fromCharset, encoding, match;
 
-        match = str.match(/^\=\?([\w_\-]+)\?([QqBb])\?([^\?]+)\?\=$/i);
+        match = str.match(/^\=\?([\w_\-]+)\?([QqBb])\?([^\?]*)\?\=$/i);
         if (!match) {
             return convert(str, toCharset);
         }
@@ -332,8 +332,8 @@ module.exports.mimeFunctions = {
         var curCharset;
 
         str = (str || "").toString().
-        replace(/(=\?[^?]+\?[QqBb]\?[^?]+\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]+\?=)/g, "$1").
-        replace(/\=\?([\w_\-]+)\?([QqBb])\?[^\?]+\?\=/g, (function(mimeWord, charset, encoding) {
+        replace(/(=\?[^?]+\?[QqBb]\?[^?]+\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]*\?=)/g, "$1").
+        replace(/\=\?([\w_\-]+)\?([QqBb])\?[^\?]*\?\=/g, (function(mimeWord, charset, encoding) {
             curCharset = charset + encoding;
             return this.decodeMimeWord(mimeWord);
         }).bind(this));


### PR DESCRIPTION
Removes 1 letter length requirement from decodeMimeWord. This enables decoding empty strings which sometimes may be sent out via mass mailers.
