### PR TITLE
Properly decode split multi-byte encodings

### DIFF
--- a/lib/mimelib.js
+++ b/lib/mimelib.js
@@ -3,6 +3,15 @@
 var convert = require("encoding").convert,
     addressparser = require("addressparser");
 
+function replaceAll(str, regex, by) {
+  var oldStr = null;
+  while (oldStr !== str) {
+      oldStr = str;
+      str = str.replace(regex, by);
+  }
+  return str;
+}
+
 /**
  * Folds a long line according to the RFC 5322 http://tools.ietf.org/html/rfc5322#section-2.1.1
  *
@@ -330,10 +339,15 @@ module.exports.mimeFunctions = {
 
     decodeMimeWords: function(str, toCharset) {
         var curCharset;
+        str = (str || "").toString().replace(/(=\?[^?]+\?[QqBb]\?[^?]+\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]*\?=)/g, "$1");
 
-        str = (str || "").toString().
-        replace(/(=\?[^?]+\?[QqBb]\?[^?]+\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]*\?=)/g, "$1").
-        replace(/\=\?([\w_\-]+)\?([QqBb])\?[^\?]*\?\=/g, (function(mimeWord, charset, encoding) {
+        var joinBRegex = /(=\?[^?]+\?[Bb]\?)([^?]+)\?=\1([^?]+)\?=/g;
+        str = replaceAll(str, joinBRegex, function(match, header, part1, part2) {
+            var result = Buffer.concat([new Buffer(part1, 'base64'), new Buffer(part2, 'base64')]).toString('base64');
+            return header + result + '?=';
+        });
+
+        str = str.replace(/\=\?([\w_\-]+)\?([QqBb])\?[^\?]*\?\=/g, (function(mimeWord, charset, encoding) {
             curCharset = charset + encoding;
             return this.decodeMimeWord(mimeWord);
         }).bind(this));

--- a/test/mimelib.js
+++ b/test/mimelib.js
@@ -116,6 +116,11 @@ exports["Mime Words"] = {
         test.done();
     },
 
+    "Join before parsing": function(test){
+        test.equal("GLG: Regulation of Taxi in China - 张一兵", mimelib.parseMimeWords("=?utf-8?B?R0xHOiBSZWd1bGF0aW9uIG9mIFRheGkgaW4gQ2hpbmEgLSDl?= =?utf-8?B?vKDkuIDlhbU=?="))
+        test.done();
+    },
+
     "Split on maxLength QP": function(test){
         var inputStr = "Jõgeva Jõgeva Jõgeva mugeva Jõgeva Jõgeva Jõgeva Jõgeva Jõgeva",
             outputStr = "=?ISO-8859-1?Q?J=F5geva_J=F5gev?= =?ISO-8859-1?Q?a_J=F5geva?= mugeva =?ISO-8859-1?Q?J=F5geva_J=F5gev?= =?ISO-8859-1?Q?a_J=F5geva_J=F5g?= =?ISO-8859-1?Q?eva_J=F5geva?=",


### PR DESCRIPTION
In a multi-byte encoding it might be possible that 2 connected bytes end up in different mime words. Therefore mime words of the same encoding have to be joined before being decoded.

This is kinda related to / solves the same problem as https://github.com/andris9/mailparser/pull/89, but joining base64 string isn't as easy as that PR makes it out to be (and also has to be done recursively...).

I'm pretty sure concatinating Q-encoding is similiar, although easier, but I don't have a test case of that lying around, so did not add it.