### PR TITLE
Join quoted-printable mimewords before decoding

### DIFF
--- a/lib/mimelib.js
+++ b/lib/mimelib.js
@@ -339,9 +339,18 @@ module.exports.mimeFunctions = {
 
     decodeMimeWords: function(str, toCharset) {
         var curCharset;
-        str = (str || "").toString().replace(/(=\?[^?]+\?[QqBb]\?[^?]+\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]*\?=)/g, "$1");
+        str = (str || "").toString();
+        var v1;
+        while (1)
+        {
+            // join quoted-printable mimeWords
+            v1 = str.replace(/(=\?[^?]+\?[Qq]\?)([^?]*)\?=\s*\1([^?]*\?=)/g, '$1$2$3');
+            if (v1 === str)
+                break;
+            str = v1;
+        }
 
-        var joinBRegex = /(=\?[^?]+\?[Bb]\?)([^?]+)\?=\1([^?]+)\?=/g;
+        var joinBRegex = /(=\?[^?]+\?[Bb]\?)([^?]+)\?=\s*\1([^?]+)\?=/g;
         str = replaceAll(str, joinBRegex, function(match, header, part1, part2) {
             var result = Buffer.concat([new Buffer(part1, 'base64'), new Buffer(part2, 'base64')]).toString('base64');
             return header + result + '?=';
@@ -349,7 +358,7 @@ module.exports.mimeFunctions = {
 
         str = str.replace(/\=\?([\w_\-]+)\?([QqBb])\?[^\?]*\?\=/g, (function(mimeWord, charset, encoding) {
             curCharset = charset + encoding;
-            return this.decodeMimeWord(mimeWord);
+            return this.decodeMimeWord(mimeWord.replace(/\s+/g, ''));
         }).bind(this));
 
         return convert(str, toCharset);


### PR DESCRIPTION
Hi!
This commit fixes decoding of badly splitted UTF8 quoted-printable headers, like

```
=?utf-8?Q?=D0=B3=D0=BE=D1=81_?==?utf-8?Q?(=D0=BF=D0=B5=D1=80=D0=B5=
 D0=B4=D0=B0=D0=B9_=D0=BA=D0=BE=D0?=
 =?utf-8?Q?=BC=D1=83_=D0=BD=D0=B0=D0=B4=D0=BE_=D1=82=D0=BE=D0=B6=D0=B5?=
```
